### PR TITLE
コンテスト成績表の取得 api を実装

### DIFF
--- a/tarareba-competition-history/go.mod
+++ b/tarareba-competition-history/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/golang/protobuf v1.4.3
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/net v0.0.0-20191119073136-fc4aabc6c914 // indirect
 	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae // indirect
 	golang.org/x/text v0.3.2 // indirect

--- a/tarareba-competition-history/service/tarareba_service.go
+++ b/tarareba-competition-history/service/tarareba_service.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
 
 	pb "github.com/monkukui/atcoder-tarareba/tarareba-competition-history/tarareba_competition_history_pb"
 )
@@ -16,30 +18,62 @@ func NewTararebaService() *TararebaService {
 
 func (s *TararebaService) GetCompetitionHistory(ctx context.Context, message *pb.GetCompetitionHistoryRequest) (*pb.GetCompetitionHistoryResponse, error) {
 
-	competition_history := &pb.CompetitionHistory{
-		IsRated:           true,
-		Place:             429,
-		OldRating:         0,
-		NewRating:         111,
-		Performance:       1571,
-		InnerPerformance:  2001111111,
-		ContestScreenName: "atcoder.com",
-		ContestName:       "AtCoder Beginner Contest 058",
-		ContestNameEn:     "",
-		EndTime:           "2020-02-02",
+	// コンテスト成績表に関する JSON を取得する
+	// コンテスト成績表はここを参照：https://atcoder.jp/users/monkukui/history
+	// コンテスト成績表に関する JSON は、この URL で取れる：https://atcoder.jp/users/monkukui/history/json
+
+	url := "https://atcoder.jp/users/" + message.UserId + "/history/json"
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
 	}
 
-	var res []*pb.CompetitionHistory
-	res = append(res, competition_history)
-	res = append(res, competition_history)
-	res = append(res, competition_history)
-
-	switch message.UserId {
-	case "monkukui":
-		return &pb.GetCompetitionHistoryResponse{
-			CompetitionHistory: res,
-		}, nil
+	var contests Contests
+	if err := json.Unmarshal(body, &contests); err != nil {
+		return nil, err
 	}
 
-	return nil, errors.New("user is not monkukui or olphe")
+	history := make([]*pb.CompetitionHistory, 0, len(contests))
+
+	for _, contest := range contests {
+		history = append(history, &pb.CompetitionHistory{
+			IsRated:           contest.IsRated,
+			Place:             uint32(contest.Place),
+			OldRating:         uint32(contest.OldRating),
+			NewRating:         uint32(contest.NewRating),
+			Performance:       uint32(contest.Performance),
+			InnerPerformance:  uint32(contest.InnerPerformance),
+			ContestScreenName: contest.ContestScreenName,
+			ContestName:       contest.ContestName,
+			ContestNameEn:     contest.ContestNameEn,
+			EndTime:           contest.EndTime,
+		})
+	}
+
+	return &pb.GetCompetitionHistoryResponse{
+		CompetitionHistory: history,
+	}, nil
 }
+
+type (
+	Contest struct {
+		IsRated           bool   `json:"IsRated"`
+		Place             int    `json:"Place"`
+		OldRating         int    `json:"OldRating"`
+		NewRating         int    `json:"NewRating"`
+		Performance       int    `json:"Performance"`
+		InnerPerformance  int    `json:"InnerPerformance"`
+		ContestScreenName string `json:"ContestScreenName"`
+		ContestName       string `json:"ContestName"`
+		ContestNameEn     string `json:"ContestNameEn"`
+		EndTime           string `json:"EndTime"`
+	}
+
+	Contests []*Contest
+)

--- a/tarareba-competition-history/service/tarareba_service_test.go
+++ b/tarareba-competition-history/service/tarareba_service_test.go
@@ -1,0 +1,110 @@
+package service
+
+import (
+	"testing"
+
+	pb "github.com/monkukui/atcoder-tarareba/tarareba-competition-history/tarareba_competition_history_pb"
+	"github.com/stretchr/testify/assert"
+)
+
+// 最初に受けたコンテストが取得できることをテストします。
+func TestCompetitionHistory_CanGetCompetitionHistory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		userID       string
+		firstContest *pb.CompetitionHistory
+	}{
+		{
+			name:   "ユーザーが monkukui のとき",
+			userID: "monkukui",
+			firstContest: &pb.CompetitionHistory{
+				IsRated:           true,
+				Place:             429,
+				OldRating:         0,
+				NewRating:         11,
+				Performance:       157,
+				InnerPerformance:  157,
+				ContestScreenName: "abc058.contest.atcoder.jp",
+				ContestName:       "AtCoder Beginner Contest 058",
+				ContestNameEn:     "",
+				EndTime:           "2017-04-08T22:40:00+09:00",
+			},
+		},
+		{
+			name:   "ユーザーが olphe のとき",
+			userID: "olphe",
+			firstContest: &pb.CompetitionHistory{
+				IsRated:           true,
+				Place:             525,
+				OldRating:         0,
+				NewRating:         146,
+				Performance:       1197,
+				InnerPerformance:  1197,
+				ContestScreenName: "agc003.contest.atcoder.jp",
+				ContestName:       "AtCoder Grand Contest 003",
+				ContestNameEn:     "",
+				EndTime:           "2016-08-21T22:50:00+09:00",
+			},
+		},
+		{
+			name:   "ユーザーが chokudai のとき",
+			userID: "chokudai",
+			firstContest: &pb.CompetitionHistory{
+				IsRated:           true,
+				Place:             59,
+				OldRating:         0,
+				NewRating:         1255,
+				Performance:       2455,
+				InnerPerformance:  2455,
+				ContestScreenName: "arc061.contest.atcoder.jp",
+				ContestName:       "AtCoder Regular Contest 061",
+				ContestNameEn:     "",
+				EndTime:           "2016-09-11T22:40:00+09:00",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewTararebaService()
+			request := pb.GetCompetitionHistoryRequest{UserId: tt.userID}
+			response, err := s.GetCompetitionHistory(nil, &request)
+
+			assert.NoError(t, err)
+			assert.NotEqual(t, 0, len(response.CompetitionHistory))
+			assert.Equal(t, tt.firstContest, response.CompetitionHistory[0])
+		})
+	}
+}
+
+// 存在しないユーザー or コンテストに出場していないとき、空配列が変えることをテストします。
+func TestCompetitionHistory_ReturnEmptySlice(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		userID string
+	}{
+		{
+			name:   "存在しないユーザーのとき",
+			userID: "not_exist_user_987315073764316328",
+		},
+		{
+			name:   "存在はするが、コンテストへの出場歴がないとき",
+			userID: "hitachi_admin",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewTararebaService()
+			request := pb.GetCompetitionHistoryRequest{UserId: tt.userID}
+			response, err := s.GetCompetitionHistory(nil, &request)
+
+			assert.NoError(t, err)
+			assert.Equal(t, 0, len(response.CompetitionHistory))
+		})
+	}
+}

--- a/tarareba-competition-history/tarareba_competition_history_pb/tarareba_competition_history.pb.go
+++ b/tarareba-competition-history/tarareba_competition_history_pb/tarareba_competition_history.pb.go
@@ -8,13 +8,14 @@ package tarareba_competition_history_pb
 
 import (
 	context "context"
+	reflect "reflect"
+	sync "sync"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/tarareba-frontend/src/App.tsx
+++ b/tarareba-frontend/src/App.tsx
@@ -7,7 +7,6 @@ import {
 } from 'react-apollo-hooks';
 
 import { appClient } from './graphql/client';
-import { GET_CONTEST_HISTORY } from './graphql/tags/getContestHistory';
 
 import ContestHistory from './components/ContestHistory';
 


### PR DESCRIPTION
## What
https://atcoder.jp/users/monkukui/history/json
のようなリンクから、コンテスト履歴を取得した。

<img width="1439" alt="スクリーンショット 2020-11-24 1 05 19" src="https://user-images.githubusercontent.com/47474057/99987928-608c2700-2df4-11eb-9f62-21cd94815484.png">


## TODO
- [ ] テストかく