### PR TITLE
Add: フロントの実装

### DIFF
--- a/tarareba-frontend/src/App.css
+++ b/tarareba-frontend/src/App.css
@@ -3,7 +3,7 @@ body {
 }
 
 .App {
-  margin: 10em;
+  margin: 5em;
   font-size: calc(10px + 1vmin);
   color: #282c34;
   min-height: 100vh;

--- a/tarareba-frontend/src/App.css
+++ b/tarareba-frontend/src/App.css
@@ -3,7 +3,9 @@ body {
 }
 
 .App {
-  margin: 5em;
+  margin-top: 5em;
+  margin-left: 15em;
+  margin-right: 15em;
   font-size: calc(10px + 1vmin);
   color: #282c34;
   min-height: 100vh;

--- a/tarareba-frontend/src/components/ContestHistory.tsx
+++ b/tarareba-frontend/src/components/ContestHistory.tsx
@@ -3,7 +3,7 @@ import { GET_CONTEST_HISTORY } from '../graphql/tags/getContestHistory'
 
 import { useQuery } from 'react-apollo-hooks'
 
-import { Table } from 'semantic-ui-react'
+import { Table, Card, Image, Button, Checkbox } from 'semantic-ui-react'
 
 import getRatingColorStyle from '../utils/getRatingColorStyle'
 
@@ -50,9 +50,60 @@ const ContestHistory: React.FC<Props> = (props) => {
       </div>
     )
   }
+
+  if (data.contestsByUserID.length == 0) {
+    console.log(data)
+    if (props.userID != '') {
+      return (
+        <div>
+          <p>ユーザーが見つかりません</p>
+        </div>
+      )
+    }
+
+    return <></>
+  }
+
+  const currentRating =
+    data.contestsByUserID[data.contestsByUserID.length - 1].actualNewRating
+  const optimalRating =
+    data.contestsByUserID[data.contestsByUserID.length - 1].optimalNewRating
+
   return (
     <>
       <div style={{ marginTop: '5em' }}>
+        <Card>
+          <Card.Content>
+            <Card.Header>結果</Card.Header>
+          </Card.Content>
+          <Table definition style={{ width: '90%', margin: '0 auto' }}>
+            <Table.Body>
+              <Table.Row>
+                <Table.Cell>実際のレート</Table.Cell>
+                <Table.Cell style={getRatingColorStyle(currentRating)}>
+                  {currentRating}
+                </Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>架空のレート</Table.Cell>
+                <Table.Cell style={getRatingColorStyle(optimalRating)}>
+                  {optimalRating}
+                </Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>差分</Table.Cell>
+                <Table.Cell style={{ fontWeight: 'bold' }}>
+                  +{optimalRating - currentRating}
+                </Table.Cell>
+              </Table.Row>
+            </Table.Body>
+          </Table>
+          <Card.Content style={{ marginTop: '2em' }}>
+            <Button basic color="green">
+              Twitter に投稿
+            </Button>
+          </Card.Content>
+        </Card>
         <Table celled={true} style={{ fontSize: 'calc(6px + 1vmin)' }}>
           <Table.Header>
             <Table.Row>
@@ -62,6 +113,7 @@ const ContestHistory: React.FC<Props> = (props) => {
               <Table.HeaderCell>パフォーマンス</Table.HeaderCell>
               <Table.HeaderCell>実際の Rating</Table.HeaderCell>
               <Table.HeaderCell>架空の Rating</Table.HeaderCell>
+              <Table.HeaderCell>参加・不参加</Table.HeaderCell>
             </Table.Row>
           </Table.Header>
 
@@ -78,7 +130,19 @@ const ContestHistory: React.FC<Props> = (props) => {
                       {record.contestName}
                     </a>
                   </Table.Cell>
-                  <Table.Cell>{record.place}</Table.Cell>
+                  <Table.Cell>
+                    <a
+                      target="_blank"
+                      href={
+                        'https://' +
+                        record.contestScreenName +
+                        '/standings?watching=' +
+                        props.userID
+                      }
+                    >
+                      {record.place}
+                    </a>
+                  </Table.Cell>
                   {record.isRated ? (
                     <>
                       <Table.Cell
@@ -90,6 +154,7 @@ const ContestHistory: React.FC<Props> = (props) => {
                         style={getRatingColorStyle(record.actualNewRating)}
                       >
                         {record.actualNewRating}
+                        &nbsp;
                         {record.actualNewRating > record.actualOldRating ? (
                           <>
                             (+{record.actualNewRating - record.actualOldRating})
@@ -97,7 +162,6 @@ const ContestHistory: React.FC<Props> = (props) => {
                         ) : (
                           <>
                             (-{record.actualOldRating - record.actualNewRating})
-                            ）
                           </>
                         )}
                       </Table.Cell>
@@ -107,6 +171,7 @@ const ContestHistory: React.FC<Props> = (props) => {
                             style={getRatingColorStyle(record.optimalNewRating)}
                           >
                             {record.optimalNewRating}
+                            &nbsp;
                             {record.optimalNewRating >
                             record.optimalOldRating ? (
                               <>
@@ -128,9 +193,13 @@ const ContestHistory: React.FC<Props> = (props) => {
                       ) : (
                         <Table.Cell>-</Table.Cell>
                       )}
+                      <Table.Cell>
+                        <Checkbox />
+                      </Table.Cell>
                     </>
                   ) : (
                     <>
+                      <Table.Cell>-</Table.Cell>
                       <Table.Cell>-</Table.Cell>
                       <Table.Cell>-</Table.Cell>
                       <Table.Cell>-</Table.Cell>

--- a/tarareba-frontend/src/components/TopPage.tsx
+++ b/tarareba-frontend/src/components/TopPage.tsx
@@ -31,10 +31,11 @@ const TopPage = () => {
           で自慢しましょう（例：あのコンテストがなかったら、俺、今頃黄色コーダーなんだが？）
         </List.Item>
       </List>
-      <Form>
+      <Form style={{ marginTop: '10em' }}>
         <Form.Input
           fluid={true}
-          placeholder={'AtCoder ID'}
+          label={'AtCoder ID'}
+          placeholder={'monkukui'}
           value={inputUserID}
           onChange={(e) => setInputUserID(e.target.value)}
         />

--- a/tarareba-frontend/src/utils/getRatingColorStyle.ts
+++ b/tarareba-frontend/src/utils/getRatingColorStyle.ts
@@ -1,26 +1,24 @@
 const getRatingColorStyle = (rating: number) => {
+  let color
   if (rating >= 2800) {
-    return { backgroundColor: 'rgb(243, 177, 176)' }
+    color = 'rgb(235, 51, 35)'
+  } else if (rating >= 2400) {
+    color = 'rgb(240, 135, 41)'
+  } else if (rating >= 2000) {
+    color = 'rgb(193, 191, 61)'
+  } else if (rating >= 1600) {
+    color = 'rgb(0, 32, 254)'
+  } else if (rating >= 1200) {
+    color = 'rgb(84, 189, 191)'
+  } else if (rating >= 800) {
+    color = 'rgb(55, 125, 34)'
+  } else if (rating >= 400) {
+    color = 'rgb(120, 67, 21)'
+  } else {
+    color = 'rgb(128, 128, 128)'
   }
-  if (rating >= 2400) {
-    return { backgroundColor: 'rgb(250, 218, 183)' }
-  }
-  if (rating >= 2000) {
-    return { backgroundColor: 'rgb(237, 235, 184)' }
-  }
-  if (rating >= 1600) {
-    return { backgroundColor: 'rgb(177, 180, 250)' }
-  }
-  if (rating >= 1200) {
-    return { backgroundColor: 'rgb(190, 235, 235)' }
-  }
-  if (rating >= 800) {
-    return { backgroundColor: 'rgb(186, 216, 181)' }
-  }
-  if (rating >= 400) {
-    return { backgroundColor: 'rgb(214, 198, 180)' }
-  }
-  return { backgroundColor: 'rgb(217, 217, 217)' }
+
+  return { color: color, fontWeight: 'bold' }
 }
 
 export default getRatingColorStyle


### PR DESCRIPTION
## What
- 実際のレートと架空のレートをカード表示
- ユーザーがコンテストを選択できるようにチェックボックスを追加
- レートの色を背景ではなく文字色に
- レートは太字に
- その他細かな修正

## スクショ
<img width="1433" alt="スクリーンショット 2020-11-28 0 46 27" src="https://user-images.githubusercontent.com/47474057/100466193-e02b3600-3113-11eb-91cb-3fe20543c5df.png">
