### PR TITLE
GetRatingTransision の型定義と bff の実装を追加

### DIFF
--- a/tarareba-algorithms/service/tarareba_service.go
+++ b/tarareba-algorithms/service/tarareba_service.go
@@ -21,10 +21,10 @@ func (s *TararebaService) GetOptimalHistory(ctx context.Context, message *pb.Get
 	for i := 0; i < len(message.ActualHistory); i++ {
 		res = append(res, &pb.OptimalHistory{
 			OldRating:      rating,
-			NewRating:      rating + 100,
+			NewRating:      rating + 31,
 			IsParticipated: (int32(i)*rating)%5 > 0,
 		})
-		rating += 100
+		rating += 31
 	}
 
 	return &pb.GetOptimalHistoryResponse{
@@ -38,11 +38,18 @@ func (s *TararebaService) GetRatingTransition(ctx context.Context, message *pb.G
 	var res []*pb.RatingTransition
 	rating := int32(0)
 	for i := 0; i < len(message.ContestPerformance); i++ {
-		res = append(res, &pb.RatingTransition{
-			OldRating: rating,
-			NewRating: rating + 100,
-		})
-		rating += 100
+		if message.ContestPerformance[i].IsParticipated {
+			res = append(res, &pb.RatingTransition{
+				OldRating: rating,
+				NewRating: rating + message.ContestPerformance[i].Performance,
+			})
+			rating += message.ContestPerformance[i].Performance
+		} else {
+			res = append(res, &pb.RatingTransition{
+				OldRating: rating,
+				NewRating: rating,
+			})
+		}
 	}
 
 	return &pb.GetRatingTransitionResponse{

--- a/tarareba-bff/graph/generated/generated.go
+++ b/tarareba-bff/graph/generated/generated.go
@@ -59,12 +59,19 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		ContestsByUserID func(childComplexity int, userID *string) int
+		ContestsByUserID              func(childComplexity int, userID *string) int
+		RatingTransitionByPerformance func(childComplexity int, isParticipated []*bool, performances []*int, innerPerformances []*int) int
+	}
+
+	RatingTransition struct {
+		NewRating func(childComplexity int) int
+		OldRating func(childComplexity int) int
 	}
 }
 
 type QueryResolver interface {
 	ContestsByUserID(ctx context.Context, userID *string) ([]*model.Contest, error)
+	RatingTransitionByPerformance(ctx context.Context, isParticipated []*bool, performances []*int, innerPerformances []*int) ([]*model.RatingTransition, error)
 }
 
 type executableSchema struct {
@@ -185,6 +192,32 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.ContestsByUserID(childComplexity, args["userID"].(*string)), true
 
+	case "Query.ratingTransitionByPerformance":
+		if e.complexity.Query.RatingTransitionByPerformance == nil {
+			break
+		}
+
+		args, err := ec.field_Query_ratingTransitionByPerformance_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.RatingTransitionByPerformance(childComplexity, args["isParticipated"].([]*bool), args["performances"].([]*int), args["innerPerformances"].([]*int)), true
+
+	case "RatingTransition.newRating":
+		if e.complexity.RatingTransition.NewRating == nil {
+			break
+		}
+
+		return e.complexity.RatingTransition.NewRating(childComplexity), true
+
+	case "RatingTransition.oldRating":
+		if e.complexity.RatingTransition.OldRating == nil {
+			break
+		}
+
+		return e.complexity.RatingTransition.OldRating(childComplexity), true
+
 	}
 	return 0, false
 }
@@ -251,8 +284,16 @@ var sources = []*ast.Source{
   isParticipated: Boolean!
 }
 
+type RatingTransition {
+  oldRating: Int!
+  newRating: Int!
+}
+
 type Query {
   contestsByUserID(userID: String): [Contest!]!
+  ratingTransitionByPerformance(isParticipated: [Boolean]!,
+                                performances: [Int]!,
+                                innerPerformances: [Int]!): [RatingTransition]!
 }
 `, BuiltIn: false},
 }
@@ -289,6 +330,39 @@ func (ec *executionContext) field_Query_contestsByUserID_args(ctx context.Contex
 		}
 	}
 	args["userID"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_ratingTransitionByPerformance_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 []*bool
+	if tmp, ok := rawArgs["isParticipated"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("isParticipated"))
+		arg0, err = ec.unmarshalNBoolean2ᚕᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["isParticipated"] = arg0
+	var arg1 []*int
+	if tmp, ok := rawArgs["performances"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("performances"))
+		arg1, err = ec.unmarshalNInt2ᚕᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["performances"] = arg1
+	var arg2 []*int
+	if tmp, ok := rawArgs["innerPerformances"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("innerPerformances"))
+		arg2, err = ec.unmarshalNInt2ᚕᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["innerPerformances"] = arg2
 	return args, nil
 }
 
@@ -827,6 +901,48 @@ func (ec *executionContext) _Query_contestsByUserID(ctx context.Context, field g
 	return ec.marshalNContest2ᚕᚖgithubᚗcomᚋmonkukuiᚋatcoderᚑtararebaᚋtararebaᚑbffᚋgraphᚋmodelᚐContestᚄ(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Query_ratingTransitionByPerformance(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Query_ratingTransitionByPerformance_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().RatingTransitionByPerformance(rctx, args["isParticipated"].([]*bool), args["performances"].([]*int), args["innerPerformances"].([]*int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.RatingTransition)
+	fc.Result = res
+	return ec.marshalNRatingTransition2ᚕᚖgithubᚗcomᚋmonkukuiᚋatcoderᚑtararebaᚋtararebaᚑbffᚋgraphᚋmodelᚐRatingTransition(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -896,6 +1012,76 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 	res := resTmp.(*introspection.Schema)
 	fc.Result = res
 	return ec.marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _RatingTransition_oldRating(ctx context.Context, field graphql.CollectedField, obj *model.RatingTransition) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "RatingTransition",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OldRating, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _RatingTransition_newRating(ctx context.Context, field graphql.CollectedField, obj *model.RatingTransition) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "RatingTransition",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewRating, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql.CollectedField, obj *introspection.Directive) (ret graphql.Marshaler) {
@@ -2109,10 +2295,56 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				}
 				return res
 			})
+		case "ratingTransitionByPerformance":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_ratingTransitionByPerformance(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "__type":
 			out.Values[i] = ec._Query___type(ctx, field)
 		case "__schema":
 			out.Values[i] = ec._Query___schema(ctx, field)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var ratingTransitionImplementors = []string{"RatingTransition"}
+
+func (ec *executionContext) _RatingTransition(ctx context.Context, sel ast.SelectionSet, obj *model.RatingTransition) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, ratingTransitionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("RatingTransition")
+		case "oldRating":
+			out.Values[i] = ec._RatingTransition_oldRating(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "newRating":
+			out.Values[i] = ec._RatingTransition_newRating(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -2384,6 +2616,36 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
+func (ec *executionContext) unmarshalNBoolean2ᚕᚖbool(ctx context.Context, v interface{}) ([]*bool, error) {
+	var vSlice []interface{}
+	if v != nil {
+		if tmp1, ok := v.([]interface{}); ok {
+			vSlice = tmp1
+		} else {
+			vSlice = []interface{}{v}
+		}
+	}
+	var err error
+	res := make([]*bool, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalOBoolean2ᚖbool(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNBoolean2ᚕᚖbool(ctx context.Context, sel ast.SelectionSet, v []*bool) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalOBoolean2ᚖbool(ctx, sel, v[i])
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalNContest2ᚕᚖgithubᚗcomᚋmonkukuiᚋatcoderᚑtararebaᚋtararebaᚑbffᚋgraphᚋmodelᚐContestᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Contest) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -2444,6 +2706,73 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNInt2ᚕᚖint(ctx context.Context, v interface{}) ([]*int, error) {
+	var vSlice []interface{}
+	if v != nil {
+		if tmp1, ok := v.([]interface{}); ok {
+			vSlice = tmp1
+		} else {
+			vSlice = []interface{}{v}
+		}
+	}
+	var err error
+	res := make([]*int, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalOInt2ᚖint(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNInt2ᚕᚖint(ctx context.Context, sel ast.SelectionSet, v []*int) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalOInt2ᚖint(ctx, sel, v[i])
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNRatingTransition2ᚕᚖgithubᚗcomᚋmonkukuiᚋatcoderᚑtararebaᚋtararebaᚑbffᚋgraphᚋmodelᚐRatingTransition(ctx context.Context, sel ast.SelectionSet, v []*model.RatingTransition) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalORatingTransition2ᚖgithubᚗcomᚋmonkukuiᚋatcoderᚑtararebaᚋtararebaᚑbffᚋgraphᚋmodelᚐRatingTransition(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {
@@ -2712,6 +3041,28 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 		return graphql.Null
 	}
 	return graphql.MarshalBoolean(*v)
+}
+
+func (ec *executionContext) unmarshalOInt2ᚖint(ctx context.Context, v interface{}) (*int, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalInt(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.SelectionSet, v *int) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return graphql.MarshalInt(*v)
+}
+
+func (ec *executionContext) marshalORatingTransition2ᚖgithubᚗcomᚋmonkukuiᚋatcoderᚑtararebaᚋtararebaᚑbffᚋgraphᚋmodelᚐRatingTransition(ctx context.Context, sel ast.SelectionSet, v *model.RatingTransition) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._RatingTransition(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOString2string(ctx context.Context, v interface{}) (string, error) {

--- a/tarareba-bff/graph/model/models_gen.go
+++ b/tarareba-bff/graph/model/models_gen.go
@@ -17,3 +17,8 @@ type Contest struct {
 	OptimalNewRating  int    `json:"optimalNewRating"`
 	IsParticipated    bool   `json:"isParticipated"`
 }
+
+type RatingTransition struct {
+	OldRating int `json:"oldRating"`
+	NewRating int `json:"newRating"`
+}

--- a/tarareba-bff/graph/schema.graphqls
+++ b/tarareba-bff/graph/schema.graphqls
@@ -14,6 +14,14 @@ type Contest {
   isParticipated: Boolean!
 }
 
+type RatingTransition {
+  oldRating: Int!
+  newRating: Int!
+}
+
 type Query {
   contestsByUserID(userID: String): [Contest!]!
+  ratingTransitionByPerformance(isParticipated: [Boolean]!,
+                                performances: [Int]!,
+                                innerPerformances: [Int]!): [RatingTransition]!
 }

--- a/tarareba-bff/tarareba_algorithms_pb/tarareba_algorithms.pb.go
+++ b/tarareba-bff/tarareba_algorithms_pb/tarareba_algorithms.pb.go
@@ -8,13 +8,14 @@ package tarareba_algorithms_pb
 
 import (
 	context "context"
+	reflect "reflect"
+	sync "sync"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/tarareba-frontend/src/App.css
+++ b/tarareba-frontend/src/App.css
@@ -4,8 +4,8 @@ body {
 
 .App {
   margin-top: 5em;
-  margin-left: 15em;
-  margin-right: 15em;
+  margin-left: 10%;
+  margin-right: 10%;
   font-size: calc(10px + 1vmin);
   color: #282c34;
   min-height: 100vh;


### PR DESCRIPTION
この api は、ユーザーが、参加するコンテストを自由に選んで、レートの推移を取得するのに使う


```
query {
    ratingTransitionByPerformance(performances: [1, 2, 10], innerPerformances: [100, 200, 300], isParticipated: [false, false, false]) {
    oldRating
    newRating
  }  
}
```


TODO
- [ ] フロントの実装

