### PR TITLE
[フロントエンド] ユーザーが参加するコンテストを選べるようにする

### DIFF
--- a/tarareba-algorithms/service/tarareba_service.go
+++ b/tarareba-algorithms/service/tarareba_service.go
@@ -41,9 +41,9 @@ func (s *TararebaService) GetRatingTransition(ctx context.Context, message *pb.G
 		if message.ContestPerformance[i].IsParticipated {
 			res = append(res, &pb.RatingTransition{
 				OldRating: rating,
-				NewRating: rating + message.ContestPerformance[i].Performance,
+				NewRating: rating + message.ContestPerformance[i].Performance/100,
 			})
-			rating += message.ContestPerformance[i].Performance
+			rating += message.ContestPerformance[i].Performance / 100
 		} else {
 			res = append(res, &pb.RatingTransition{
 				OldRating: rating,

--- a/tarareba-frontend/src/components/ContestHistory.tsx
+++ b/tarareba-frontend/src/components/ContestHistory.tsx
@@ -39,27 +39,11 @@ const ContestHistory: React.FC<Props> = (props) => {
     },
   })
 
+  // GraphQL からデータが取得できたら、contest にデータをバインディングする
+  // 以降は、contest をフロントエンドで管理して、表示を切り替える（AtCoder にアクセスするのは最初に一回だけ）
   useEffect(() => {
     if (!loading && !error && data) {
-      let c: Contest[] = []
-      data!.contestsByUserID.map((record) => {
-        c.push({
-          isRated: record.isRated,
-          place: record.place,
-          actualOldRating: record.actualOldRating,
-          actualNewRating: record.actualNewRating,
-          performance: record.performance,
-          innerPerformance: record.innerPerformance,
-          contestScreenName: record.contestScreenName,
-          contestName: record.contestName,
-          contestNameEn: record.contestNameEn,
-          endTime: record.endTime,
-          optimalOldRating: record.optimalOldRating,
-          optimalNewRating: record.optimalNewRating,
-          isParticipated: record.isParticipated,
-        })
-      })
-      setContest(c)
+      setContest(data.contestsByUserID)
     }
   }, [data])
 
@@ -96,7 +80,6 @@ const ContestHistory: React.FC<Props> = (props) => {
 
   return (
     <>
-      <div>{contest.length}</div>
       <div style={{ marginTop: '5em' }}>
         <Card>
           <Card.Content>
@@ -222,7 +205,16 @@ const ContestHistory: React.FC<Props> = (props) => {
                         <Table.Cell>-</Table.Cell>
                       )}
                       <Table.Cell>
-                        <Checkbox />
+                        <Checkbox
+                          checked={record.isParticipated}
+                          onClick={() => {
+                            // 別関数でやる
+                            // 1. useLazyQuery で、bff サーバーにクエリを投げる
+                            // 2. 今の contest と帰ってきた情報を組み合わせて、新しい contest を作成する
+                            // 3. setContest([...]) で contest を更新
+                            setContest([])
+                          }}
+                        />
                       </Table.Cell>
                     </>
                   ) : (

--- a/tarareba-frontend/src/components/ContestHistory.tsx
+++ b/tarareba-frontend/src/components/ContestHistory.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { GET_CONTEST_HISTORY } from '../graphql/tags/getContestHistory'
 
 import { useQuery } from 'react-apollo-hooks'
@@ -32,14 +32,38 @@ type Props = {
 }
 
 const ContestHistory: React.FC<Props> = (props) => {
-  // マウント時にリクエストが走る
+  const [contest, setContest] = useState<Contest[]>([])
   const { loading, error, data } = useQuery<Contests>(GET_CONTEST_HISTORY, {
     variables: {
       userID: props.userID,
     },
   })
 
-  if (loading) return <div>loading</div>
+  useEffect(() => {
+    if (!loading && !error && data) {
+      let c: Contest[] = []
+      data!.contestsByUserID.map((record) => {
+        c.push({
+          isRated: record.isRated,
+          place: record.place,
+          actualOldRating: record.actualOldRating,
+          actualNewRating: record.actualNewRating,
+          performance: record.performance,
+          innerPerformance: record.innerPerformance,
+          contestScreenName: record.contestScreenName,
+          contestName: record.contestName,
+          contestNameEn: record.contestNameEn,
+          endTime: record.endTime,
+          optimalOldRating: record.optimalOldRating,
+          optimalNewRating: record.optimalNewRating,
+          isParticipated: record.isParticipated,
+        })
+      })
+      setContest(c)
+    }
+  }, [data])
+
+  if (loading || !contest) return <div>loading</div>
   if (error) {
     return (
       <div>
@@ -51,9 +75,8 @@ const ContestHistory: React.FC<Props> = (props) => {
     )
   }
 
-  if (data!.contestsByUserID.length == 0) {
-    console.log(data)
-    if (props.userID != '') {
+  if (data!.contestsByUserID.length === 0) {
+    if (props.userID !== '') {
       return (
         <div>
           <p>ユーザーが見つかりません</p>
@@ -73,6 +96,7 @@ const ContestHistory: React.FC<Props> = (props) => {
 
   return (
     <>
+      <div>{contest.length}</div>
       <div style={{ marginTop: '5em' }}>
         <Card>
           <Card.Content>
@@ -120,27 +144,29 @@ const ContestHistory: React.FC<Props> = (props) => {
           </Table.Header>
 
           <Table.Body>
-            {data!.contestsByUserID.map((record) => {
+            {contest!.map((record) => {
               return (
                 <Table.Row key={record.endTime}>
                   <Table.Cell>{record.endTime}</Table.Cell>
                   <Table.Cell>
                     <a
-                      target="_blank"
                       href={'https://' + record.contestScreenName}
+                      rel="noreferrer noreferrer"
+                      target="_blank"
                     >
                       {record.contestName}
                     </a>
                   </Table.Cell>
                   <Table.Cell>
                     <a
-                      target="_blank"
                       href={
                         'https://' +
                         record.contestScreenName +
                         '/standings?watching=' +
                         props.userID
                       }
+                      rel="noreferrer noreferrer"
+                      target="_blank"
                     >
                       {record.place}
                     </a>

--- a/tarareba-frontend/src/components/ContestHistory.tsx
+++ b/tarareba-frontend/src/components/ContestHistory.tsx
@@ -47,6 +47,21 @@ const ContestHistory: React.FC<Props> = (props) => {
     }
   }, [data])
 
+  // index 番目の contest の参加履歴を更新する
+  // GraphQL サーバーにレート推移計算のクエリを投げる
+  // contest 全体を更新する
+  const updateContest = (index: number) => {
+    console.log(index)
+    let c: Contest[] = []
+    contest.map((record, i) => {
+      c.push(record)
+      if (i === index) {
+        c[c.length - 1].isParticipated = !c[c.length - 1].isParticipated
+      }
+    })
+    setContest(c)
+  }
+
   if (loading || !contest) return <div>loading</div>
   if (error) {
     return (
@@ -127,7 +142,7 @@ const ContestHistory: React.FC<Props> = (props) => {
           </Table.Header>
 
           <Table.Body>
-            {contest!.map((record) => {
+            {contest!.map((record, index) => {
               return (
                 <Table.Row key={record.endTime}>
                   <Table.Cell>{record.endTime}</Table.Cell>
@@ -208,12 +223,16 @@ const ContestHistory: React.FC<Props> = (props) => {
                         <Checkbox
                           checked={record.isParticipated}
                           onClick={() => {
+                            updateContest(index)
+                          }}
+                          /*onClick={() => {
                             // 別関数でやる
                             // 1. useLazyQuery で、bff サーバーにクエリを投げる
                             // 2. 今の contest と帰ってきた情報を組み合わせて、新しい contest を作成する
                             // 3. setContest([...]) で contest を更新
-                            setContest([])
-                          }}
+                            console.log(index);
+
+                          }}*/
                         />
                       </Table.Cell>
                     </>

--- a/tarareba-frontend/src/graphql/tags/getContestHistory.ts
+++ b/tarareba-frontend/src/graphql/tags/getContestHistory.ts
@@ -1,6 +1,6 @@
-import gql from 'graphql-tag';
+import gql from 'graphql-tag'
 
-// クエリ定義
+// AtCoder ID を受け取り、コンテスト情報を返す
 export const GET_CONTEST_HISTORY = gql`
   query($userID: String!) {
     contestsByUserID(userID: $userID) {
@@ -18,5 +18,14 @@ export const GET_CONTEST_HISTORY = gql`
       optimalNewRating
       isParticipated
     }
+  }
+`
+// パフォーマンス列を受け取り、レート推移を返す
+export const GET_RATING_TRANSITION = gql`
+  query($isParticipated: [Boolean]!, $performances: [Int]!, $innerPerformance: [Int]!) {
+    ratingTransitionByPerformance(isParticipated: $isParticipated, performances: $performance, innerPerformances: $innerPerformance {
+      oldRating
+      newRating
+    }  
   }
 `

--- a/tarareba-frontend/src/graphql/tags/getContestHistory.ts
+++ b/tarareba-frontend/src/graphql/tags/getContestHistory.ts
@@ -22,10 +22,18 @@ export const GET_CONTEST_HISTORY = gql`
 `
 // パフォーマンス列を受け取り、レート推移を返す
 export const GET_RATING_TRANSITION = gql`
-  query($isParticipated: [Boolean]!, $performances: [Int]!, $innerPerformance: [Int]!) {
-    ratingTransitionByPerformance(isParticipated: $isParticipated, performances: $performance, innerPerformances: $innerPerformance {
+  query(
+    $isParticipated: [Boolean]!
+    $performances: [Int]!
+    $innerPerformances: [Int]!
+  ) {
+    ratingTransitionByPerformance(
+      isParticipated: $isParticipated
+      performances: $performances
+      innerPerformances: $innerPerformances
+    ) {
       oldRating
       newRating
-    }  
+    }
   }
 `


### PR DESCRIPTION
## What
- useState, useEffect を用いて、contest の状態管理のロジックを追加

## TODO
- [x] useLazyQuery を用いて、チェックボックスを押すきっかけでクエリを飛ばすようにする。
- [x] それに伴い、`contest` を更新する。AtCoder に再度リクエストは飛ばさない。最初の一回だけ。

## Ref
- [useLazyQuery](https://qiita.com/sonatard/items/42b319409e074518be09)